### PR TITLE
chore: claim moose namespaces

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/release-igloo-cli.yaml"
+      - ".github/workflows/release-cli.yaml"
       - "apps/igloo-cli-npm/**"
+      - "apps/moose-cli-npm/**"
       - "apps/igloo-kit-cli/**"
       - "apps/create-igloo-app/**"
+      - "apps/create-moose-app/**"
       - "packages/**"
 
 jobs:
@@ -105,9 +107,17 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Publish to NPM
+      # TO Be DELETED when migration to new name is over
+      - name: Publish to NPM Igloo
         shell: bash
         working-directory: ./apps/igloo-cli-npm
+        run: ./scripts/release-bin.sh ${{ needs.version.outputs.version }} ${{ matrix.build.TARGET }} ${{ matrix.build.OS }} ${{ matrix.build.NAME }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to NPM Moose
+        shell: bash
+        working-directory: ./apps/moose-cli-npm
         run: ./scripts/release-bin.sh ${{ needs.version.outputs.version }} ${{ matrix.build.TARGET }} ${{ matrix.build.OS }} ${{ matrix.build.NAME }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -149,13 +159,23 @@ jobs:
           node-version: "18"
           cache: "pnpm"
 
-      - name: Publish the NPM CLI package
+      # TO Be DELETED when migration to new name is over
+      - name: Publish the NPM Igloo CLI package
         shell: bash
         run: ./apps/igloo-cli-npm/scripts/release-cli.sh ${{ needs.version.outputs.version }}
 
-      - name: Publish the NPM create app package
+      # TO Be DELETED when migration to new name is over
+      - name: Publish the NPM Igloo create app package
         shell: bash
         run: ./apps/create-igloo-app/scripts/release.sh ${{ needs.version.outputs.version }}
+
+      - name: Publish the NPM Moose CLI package
+        shell: bash
+        run: ./apps/moose-cli-npm/scripts/release-cli.sh ${{ needs.version.outputs.version }}
+
+      - name: Publish the NPM Moose create app package
+        shell: bash
+        run: ./apps/create-moose-app/scripts/release.sh ${{ needs.version.outputs.version }}
 
       - name: Notify Sentry release
         uses: getsentry/action-release@v1

--- a/apps/create-moose-app/package.json
+++ b/apps/create-moose-app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "create-moose-app",
+  "version": "0.0.0",
+  "description": "Create Moose apps with one command",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/514-labs/igloo-stack/issues",
+    "directory": "apps/create-moose-app"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "license": "MIT",
+  "bin": "./dist/index.js",
+  "devDependencies": {
+    "@types/node": "18.16.19",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
+    "eslint": "^8.46.0",
+    "tsconfig": "workspace:0.0.0",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@514labs/moose-cli": "latest"
+  }
+}

--- a/apps/create-moose-app/package.json
+++ b/apps/create-moose-app/package.json
@@ -24,6 +24,6 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@514labs/moose-cli": "latest"
+    "moose": "latest"
   }
 }

--- a/apps/create-moose-app/scripts/release.sh
+++ b/apps/create-moose-app/scripts/release.sh
@@ -1,0 +1,16 @@
+#/usr/bin/env bash
+
+version=$1
+
+cd apps/create-moose-app
+npm version $version --no-git-tag-version
+
+jq \
+    --arg VERSION "$version" \
+    '.["dependencies"]["@514labs/moose-cli"] = $VERSION' package.json > package.json.tmp \
+    && mv package.json.tmp package.json
+
+cd ../..
+pnpm build --filter create-moose-app
+cd apps/create-moose-app
+pnpm publish --access public --no-git-checks

--- a/apps/create-moose-app/scripts/release.sh
+++ b/apps/create-moose-app/scripts/release.sh
@@ -7,7 +7,7 @@ npm version $version --no-git-tag-version
 
 jq \
     --arg VERSION "$version" \
-    '.["dependencies"]["@514labs/moose-cli"] = $VERSION' package.json > package.json.tmp \
+    '.["dependencies"]["moose"] = $VERSION' package.json > package.json.tmp \
     && mv package.json.tmp package.json
 
 cd ../..

--- a/apps/create-moose-app/src/index.ts
+++ b/apps/create-moose-app/src/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+
+/**
+ * Returns the executable path which is located inside `node_modules`
+ * The naming convention is app-${os}-${arch}
+ * If the platform is `win32` or `cygwin`, executable will include a `.exe` extension.
+ * @see https://nodejs.org/api/os.html#osarch
+ * @see https://nodejs.org/api/os.html#osplatform
+ * @example "x/xx/node_modules/app-darwin-arm64"
+ */
+function getExePath() {
+  const arch = process.arch;
+  let os = process.platform as string;
+  let extension = "";
+  if (["win32", "cygwin"].includes(process.platform)) {
+    os = "windows";
+    extension = ".exe";
+  }
+
+  try {
+    // Since the binary will be located inside `node_modules`, we can simply call `require.resolve`
+    return require.resolve(
+      `@514labs/moose-cli-${os}-${arch}/bin/igloo-cli${extension}`
+    );
+  } catch (e) {
+    throw new Error(
+      `Couldn't find application binary inside node_modules for ${os}-${arch}`
+    );
+  }
+}
+
+/**
+ * Runs the application with args using nodejs spawn
+ */
+function run() {
+  const args = process.argv.slice(2);
+  const processResult = spawnSync(getExePath(), ["init"].concat(args), {
+    stdio: "inherit",
+  });
+  process.exit(processResult.status ?? 0);
+}
+
+run();

--- a/apps/create-moose-app/tsconfig.json
+++ b/apps/create-moose-app/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  }
+}

--- a/apps/moose-cli-npm/README.md
+++ b/apps/moose-cli-npm/README.md
@@ -1,0 +1,87 @@
+# Moose CLI
+
+The Moose CLI is your entrypoint to a seamless, local development experience for you data-intensive application. It's written in rust and supports building applications in TypeScript and Python.
+
+## Installation
+
+Before getting started you'll need to install some dependencies on your machine:
+
+1. Node
+2. Docker
+
+The Moose CLI is available as an NPM. To install the CLI, run the following command:
+
+```bash
+npm install -g moose
+```
+
+## Usage
+
+The Moose CLI is a command-line tool that allows you to create, manage, and deploy your Moose applications.
+
+### Creating a new application
+
+To create a new application, run the following command:
+
+```bash
+igloo init
+```
+
+This will prompt you to enter a name for your application. Once you have entered a name, the CLI will create a new directory with the name you provided and scaffold out a new Moose application.
+
+#### Application structure
+
+The CLI will create the following files and directories:
+
+```
+├── .igloo
+│   ├── .clickhouse
+│   ├── .redpanda
+│   └── ...
+├── .gitignore
+├── README.md
+├── package.json or requirements.txt
+├── app
+│   ├── index.ts or index.py
+│   ├── dataframes
+│   │   └── ...
+│   ├── flows
+│   │   └── ...
+│   ├── ingests
+│   │   └── ...
+│   ├── insights
+│   │   ├── dashboards
+│   │   ├── metrics
+│   │   ├── models
+│   │   └── ...
+│   └── utils
+```
+
+##### `app` directory
+
+The `app` directory contains all of the code for your application. This includes all of the dataframes, flows, ingests, and insights that make up your application. This directory is where you will spend most of your time developing your application.
+
+##### `.igloo` for contributors only
+
+The `.igloo` directory contains all of the configuration files for an application. This includes configuration for the local state of the application as well as any required local infrastructure. This directory is only used by contributors to the application and should not be committed to source control. Modifying files in this directory may cause unexpected behavior.
+
+### Running your application in development mode
+
+To run your application, run the following command:
+
+```bash
+igloo dev
+```
+
+This will start all of the required infrastructure and run your application in development mode. You can now make changes to your application and see them reflected in real-time.
+
+### Seeing your application in action
+
+Once your application is running, you can see it in action by navigating to the following URLs:
+
+- [http://localhost:4000](http://localhost:4000) - Your application's interface if you've created one
+- [http://localhost:4000/console](http://localhost:4000/console) - A console to see the data flowing through your application and the objects you've created
+
+#### The console
+
+The console is a great way to see the data flowing through your application. It allows you to see the data flowing through your application in real-time and interact with the objects you've created. You can also use the console to run queries against your application's data.

--- a/apps/moose-cli-npm/package.json
+++ b/apps/moose-cli-npm/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "moose",
+  "version": "0.0.0",
+  "bin": {
+    "igloo": "dist/index.js",
+    "igloo-cli": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "18.16.19",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
+    "eslint": "^8.46.0",
+    "tsconfig": "workspace:0.0.0",
+    "typescript": "^4.9.5"
+  },
+  "optionalDependencies": {
+    "@514labs/moose-cli-darwin-arm64": "latest",
+    "@514labs/moose-cli-darwin-x64": "latest",
+    "@514labs/moose-cli-linux-arm64": "latest",
+    "@514labs/moose-cli-linux-x64": "latest",
+    "@514labs/moose-cli-windows-arm64": "latest",
+    "@514labs/moose-cli-windows-x64": "latest"
+  }
+}

--- a/apps/moose-cli-npm/package.json.tmpl
+++ b/apps/moose-cli-npm/package.json.tmpl
@@ -1,0 +1,6 @@
+{
+  "name": "@514labs/${node_pkg}",
+  "version": "${node_version}",
+  "os": ["${node_os}"],
+  "cpu": ["${node_arch}"]
+}

--- a/apps/moose-cli-npm/scripts/release-bin.sh
+++ b/apps/moose-cli-npm/scripts/release-bin.sh
@@ -1,0 +1,41 @@
+#/usr/bin/env bash
+
+export node_version=$1
+build_target=$2
+build_os=$3
+build_name=$4
+
+# set the binary name
+bin="igloo-cli"
+# derive the OS and architecture from the build matrix name
+# note: when split by a hyphen, first part is the OS and the second is the architecture
+node_os=$(echo ${build_name} | cut -d '-' -f1)
+export node_os
+node_arch=$(echo ${build_name} | cut -d '-' -f2)
+export node_arch
+
+# set the version
+
+# set the package name
+# note: use 'windows' as OS name instead of 'win32'
+if [ ${build_os} = "windows-2022" ]; then
+    export node_pkg="${bin}-windows-${node_arch}"
+else
+    export node_pkg="${bin}-${node_os}-${node_arch}"
+fi
+# create the package directory
+mkdir -p "${node_pkg}/bin"
+# generate package.json from the template
+envsubst < package.json.tmpl > "${node_pkg}/package.json"
+# copy the binary into the package
+# note: windows binaries has '.exe' extension
+if [ $build_os = "windows-2022" ]; then
+    bin="${bin}.exe"
+fi
+pwd
+ls "../igloo-kit-cli/target/${build_target}/release/${bin}"
+cp "../igloo-kit-cli/target/${build_target}/release/${bin}" "../igloo-kit-cli/target/${build_target}/release/${bin}-${build_target}"
+cp "../igloo-kit-cli/target/${build_target}/release/${bin}" "${node_pkg}/bin"
+# publish the package
+cd "${node_pkg}"
+npm publish --access public

--- a/apps/moose-cli-npm/scripts/release-cli.sh
+++ b/apps/moose-cli-npm/scripts/release-cli.sh
@@ -1,0 +1,27 @@
+#/usr/bin/env bash
+
+# This script should be called from the root of the repository
+
+version=$1
+
+cd ./apps/moose-cli-npm
+npm version $version --no-git-tag-version
+
+# change all the dependencies in the package.json optionalDependencies to use 
+# the BUILD version
+jq -r '.optionalDependencies | keys[]' package.json | while read dep; do
+#   pnpm up $dep $version
+  jq \
+    --arg DEP "$dep" \
+    --arg VERSION "$version" \
+    '.["optionalDependencies"][$DEP] = $VERSION' package.json > package.json.tmp \
+    && mv package.json.tmp package.json
+done
+cd ../..
+
+# # This is run twice since the change the value of the dependencies in the previous step
+pnpm install --no-frozen-lockfile # requires optional dependencies to be present in the registry
+pnpm build --filter moose
+
+cd apps/moose-cli-npm
+pnpm publish --access public --no-git-checks

--- a/apps/moose-cli-npm/src/index.ts
+++ b/apps/moose-cli-npm/src/index.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+
+/**
+ * Returns the executable path which is located inside `node_modules`
+ * The naming convention is app-${os}-${arch}
+ * If the platform is `win32` or `cygwin`, executable will include a `.exe` extension.
+ * @see https://nodejs.org/api/os.html#osarch
+ * @see https://nodejs.org/api/os.html#osplatform
+ * @example "x/xx/node_modules/app-darwin-arm64"
+ */
+function getExePath() {
+  const arch = process.arch;
+  let os = process.platform as string;
+  let extension = "";
+  if (["win32", "cygwin"].includes(process.platform)) {
+    os = "windows";
+    extension = ".exe";
+  }
+
+  if (os.startsWith("windows")) {
+    throw new Error(
+      "Windows is not supported yet. If you are a windows user, interested in windows support, please give us a shout at https://discord.gg/WX3V3K4QCc"
+    );
+  }
+
+  try {
+    // Since the binary will be located inside `node_modules`, we can simply call `require.resolve`
+    return require.resolve(
+      `@514labs/moose-cli-${os}-${arch}/bin/igloo-cli${extension}`
+    );
+  } catch (e) {
+    throw new Error(
+      `Couldn't find application binary inside node_modules for ${os}-${arch}`
+    );
+  }
+}
+
+/**
+ * Runs the application with args using nodejs spawn
+ */
+function run() {
+  const args = process.argv.slice(2);
+  const processResult = spawnSync(getExePath(), args, { stdio: "inherit" });
+  process.exit(processResult.status ?? 0);
+}
+
+run();

--- a/apps/moose-cli-npm/tsconfig.json
+++ b/apps/moose-cli-npm/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,31 @@ importers:
         specifier: ^4.9.5
         version: 4.9.5
 
+  apps/create-moose-app:
+    dependencies:
+      '@514labs/moose-cli':
+        specifier: latest
+        version: link:../moose-cli-npm
+    devDependencies:
+      '@types/node':
+        specifier: 18.16.19
+        version: 18.16.19
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.62.0
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^5.62.0
+        version: 5.62.0(eslint@8.48.0)(typescript@4.9.5)
+      eslint:
+        specifier: ^8.46.0
+        version: 8.48.0
+      tsconfig:
+        specifier: workspace:0.0.0
+        version: link:../../packages/tsconfig
+      typescript:
+        specifier: ^4.9.5
+        version: 4.9.5
+
   apps/igloo-cli-npm:
     optionalDependencies:
       '@514labs/igloo-cli-darwin-arm64':
@@ -62,13 +87,13 @@ importers:
         version: 0.3.23
       '@514labs/igloo-cli-darwin-x64':
         specifier: latest
-        version: 0.3.23
+        version: 0.3.24
       '@514labs/igloo-cli-linux-arm64':
         specifier: latest
         version: 0.3.23
       '@514labs/igloo-cli-linux-x64':
         specifier: latest
-        version: 0.3.23
+        version: 0.3.24
       '@514labs/igloo-cli-windows-arm64':
         specifier: latest
         version: 0.0.2-BUILD.73
@@ -160,6 +185,27 @@ importers:
         version: link:../../packages/tsconfig
       typescript:
         specifier: ^4.9.4
+        version: 4.9.5
+
+  apps/moose-cli-npm:
+    devDependencies:
+      '@types/node':
+        specifier: 18.16.19
+        version: 18.16.19
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.62.0
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.48.0)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^5.62.0
+        version: 5.62.0(eslint@8.48.0)(typescript@4.9.5)
+      eslint:
+        specifier: ^8.46.0
+        version: 8.48.0
+      tsconfig:
+        specifier: workspace:0.0.0
+        version: link:../../packages/tsconfig
+      typescript:
+        specifier: ^4.9.5
         version: 4.9.5
 
   apps/web:
@@ -303,6 +349,14 @@ packages:
     dev: false
     optional: true
 
+  /@514labs/igloo-cli-darwin-x64@0.3.24:
+    resolution: {integrity: sha512-+TYeBJXJv1InSztBgnZsduXXkwFQ8CFu49kIMfZP5cKkMgdo8eVeK1ySUAS63qm3MUSzwnfezVeAib35Crea9Q==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@514labs/igloo-cli-linux-arm64@0.3.23:
     resolution: {integrity: sha512-eoNoA9B6swILkcMhR08cgWjSIJIruaNPW2saTWZDG04VzXbkunfDLDcsRXHxAmJFrA9y4g2t0xb8dU76uK2e3g==}
     cpu: [arm64]
@@ -313,6 +367,14 @@ packages:
 
   /@514labs/igloo-cli-linux-x64@0.3.23:
     resolution: {integrity: sha512-aVt4UbtNq34XgLdxo3N9cISheGuHbdniS9XwK4HsbjC+QPVTKeKvaOCrBynCFvPu5zUH/IxTCoXMFKLBM6V2rA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@514labs/igloo-cli-linux-x64@0.3.24:
+    resolution: {integrity: sha512-oRQKf6X9PSrm1VPZjQwQn3xKdh8ABvUC8D6/AEyQ36NDTDkOpqDQnKIb+MbvSvYrwEpU3nzFwz5AXbMUU2makA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -2085,7 +2147,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.6.2
+      '@eslint-community/regexpp': 4.8.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.48.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.48.0)(typescript@4.9.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,9 @@ importers:
 
   apps/create-moose-app:
     dependencies:
-      '@514labs/moose-cli':
+      moose:
         specifier: latest
-        version: link:../moose-cli-npm
+        version: 0.0.3
     devDependencies:
       '@types/node':
         specifier: 18.16.19
@@ -2692,6 +2692,10 @@ packages:
     engines: {node: '>=0.6'}
     dev: false
 
+  /bignumber.js@9.0.0:
+    resolution: {integrity: sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==}
+    dev: false
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -2988,6 +2992,11 @@ packages:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
     dev: true
 
+  /comb@2.0.0:
+    resolution: {integrity: sha512-QYzY8XlE6r3vembg/TbiSaD2KI6Sp1dtf/rk5tahf6tXGjqkpe6SVwkouk/v+cckn1EQsX0jjUL8Hb98dc4ZVw==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -3036,6 +3045,10 @@ packages:
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
+
+  /core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    dev: false
 
   /cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -3531,6 +3544,11 @@ packages:
     resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /diff@5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
@@ -4380,6 +4398,11 @@ packages:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     dev: false
 
+  /eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4880,6 +4903,15 @@ packages:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: false
 
+  /hive-cache@0.0.3:
+    resolution: {integrity: sha512-a0b/TzuvlYq2STj4lFN8FtbbGJ2pINBzsz6tnXRptfmYrfgbpr754Iae2mxo/1b+lHXZF1h3l+EMNuWR8ZdUeQ==}
+    engines: {node: '>= 0.6.1'}
+    deprecated: This package is no longer maintained. Use at your own risk.
+    dependencies:
+      comb: 2.0.0
+      vows: 0.8.3
+    dev: false
+
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -5281,6 +5313,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+    dev: false
+
+  /isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
     dev: false
 
   /isarray@2.0.5:
@@ -6733,6 +6769,16 @@ packages:
       minimist: 1.2.8
     dev: false
 
+  /moose@0.0.3:
+    resolution: {integrity: sha512-fbhjp5dmgveWBi3hc1fk4bwfN13x3upzZpGJcjN+paBi2XfQ9Iv72wtuoY3fDCdv9PxOwKCILJkGOJMWuG5iOA==}
+    engines: {node: '>= 0.6.1'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      comb: 2.0.0
+      hive-cache: 0.0.3
+      mysql: 2.18.1
+    dev: false
+
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -6743,6 +6789,16 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /mysql@2.18.1:
+    resolution: {integrity: sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      bignumber.js: 9.0.0
+      readable-stream: 2.3.7
+      safe-buffer: 5.1.2
+      sqlstring: 2.3.1
     dev: false
 
   /mz@2.7.0:
@@ -7397,6 +7453,10 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    dev: false
+
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -7505,6 +7565,18 @@ packages:
     dependencies:
       pify: 2.3.0
     dev: true
+
+  /readable-stream@2.3.7:
+    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: false
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -7771,6 +7843,10 @@ packages:
       isarray: 2.0.5
     dev: false
 
+  /safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    dev: false
+
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: false
@@ -7974,6 +8050,11 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  /sqlstring@2.3.1:
+    resolution: {integrity: sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -8074,6 +8155,12 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       es-abstract: 1.22.1
+    dev: false
+
+  /string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    dependencies:
+      safe-buffer: 5.1.2
     dev: false
 
   /string_decoder@1.3.0:
@@ -8830,6 +8917,15 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
+    dev: false
+
+  /vows@0.8.3:
+    resolution: {integrity: sha512-PVIxa/ovXhrw5gA3mz6M+ZF3PHlqX4tutR2p/y9NWPAaFVKcWBE8b2ktfr0opQM/qFmcOVWKjSCJVjnYOvjXhw==}
+    hasBin: true
+    dependencies:
+      diff: 4.0.2
+      eyes: 0.1.8
+      glob: 7.2.3
     dev: false
 
   /vscode-oniguruma@1.7.0:


### PR DESCRIPTION
* adds `moose` as a package name we claim for the CLI on npm
* adds `create-moose-app` as a package for the shortcut to init
* Updates workflows to automatically publish changes to moose alongside igloo for now